### PR TITLE
Refactor metrics and sensor modules for easier testing

### DIFF
--- a/src/strudel/lib.rs
+++ b/src/strudel/lib.rs
@@ -85,16 +85,17 @@
 //! `strudel` as a target under the Prometheus `scrape_configs` section as described by
 //! the example below.
 //!
-//! **NOTE**: The DHT22 sensor can only be read every two seconds, at most. Thus, the most
-//! frequent Prometheus scrape interval that `strudel` can support is `2s`. Something a bit
-//! longer (like `10s` or `15s`) is recommended.
+//! **NOTE**: The DHT22 sensor can only be read every two seconds, at most. By default, the
+//! sensor is read every `30s`, in the background (*not* in response to Prometheus scrapes).
+//! Thus, scrapes by Prometheus more frequent than `30s` don't have any benefit unless the
+//! refresh interval for `strudel` is adjusted as well.
 //!
 //! ```yaml
 //! # Sample config for Prometheus.
 //!
 //! global:
-//!   scrape_interval:     15s
-//!   evaluation_interval: 15s
+//!   scrape_interval:     1m
+//!   evaluation_interval: 1m
 //!   external_labels:
 //!       monitor: 'my_prom'
 //!

--- a/src/strudel/sensor/core.rs
+++ b/src/strudel/sensor/core.rs
@@ -1,0 +1,189 @@
+// Strudel - Temperature and humidity metrics exporter for Prometheus
+//
+// Copyright 2021 Nick Pillitteri
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+use std::error::Error;
+use std::fmt::{self, Formatter};
+
+use rppal::gpio::{Gpio, IoPin, Mode};
+
+/// Temperature, in degrees celsius
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(transparent)]
+pub struct TemperatureCelsius(f64);
+
+impl From<TemperatureCelsius> for f64 {
+    fn from(v: TemperatureCelsius) -> Self {
+        v.0
+    }
+}
+
+impl From<f64> for TemperatureCelsius {
+    fn from(v: f64) -> Self {
+        Self(v)
+    }
+}
+
+impl fmt::Display for TemperatureCelsius {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}c", self.0)
+    }
+}
+
+/// Relative humidity (from 0 to 100)
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(transparent)]
+pub struct Humidity(f64);
+
+impl From<Humidity> for f64 {
+    fn from(v: Humidity) -> Self {
+        v.0
+    }
+}
+
+impl From<f64> for Humidity {
+    fn from(v: f64) -> Self {
+        Self(v)
+    }
+}
+
+impl fmt::Display for Humidity {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}%", self.0)
+    }
+}
+
+/// Potential kinds of errors that can be encountered reading from the DHT sensor
+#[derive(PartialEq, Eq, Debug, Hash, Clone, Copy)]
+pub enum SensorErrorKind {
+    Initialization,
+    ReadTimeout,
+    Checksum,
+}
+
+impl SensorErrorKind {
+    pub fn as_label(&self) -> &'static str {
+        match self {
+            SensorErrorKind::Initialization => "initialization",
+            SensorErrorKind::ReadTimeout => "timeout",
+            SensorErrorKind::Checksum => "checksum",
+        }
+    }
+}
+
+/// Error initializing or reading the DHT22 sensor via a GPIO pin
+#[derive(Debug)]
+pub enum SensorError {
+    CheckSum(u8, u8),
+    KindMsg(SensorErrorKind, &'static str),
+    KindMsgCause(SensorErrorKind, &'static str, Box<dyn Error + Send + Sync>),
+}
+
+impl SensorError {
+    pub fn kind(&self) -> SensorErrorKind {
+        match self {
+            SensorError::CheckSum(_, _) => SensorErrorKind::Checksum,
+            SensorError::KindMsg(kind, _) => *kind,
+            SensorError::KindMsgCause(kind, _, _) => *kind,
+        }
+    }
+}
+
+impl fmt::Display for SensorError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            SensorError::CheckSum(expected, got) => {
+                write!(f, "checksum error: expected {}, got {}", expected, got)
+            }
+            SensorError::KindMsg(_, msg) => msg.fmt(f),
+            SensorError::KindMsgCause(_, msg, ref e) => write!(f, "{}: {}", msg, e),
+        }
+    }
+}
+
+impl Error for SensorError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            SensorError::KindMsgCause(_, _, ref e) => Some(e.as_ref()),
+            _ => None,
+        }
+    }
+}
+
+/// Create a new `IoPin` based on the BCM GPIO pin number of the data wire of a
+/// sensor.
+///
+/// Note that the BCM GPIO pin number is NOT the same as the physical pin number.
+/// See [pinout] for more information.
+///
+/// [pinout]: https://www.raspberrypi.com/documentation/computers/os.html#gpio-and-the-40-pin-header
+pub fn open_pin(bcm_gpio_pin: u8) -> Result<IoPin, SensorError> {
+    let controller = Gpio::new().map_err(|e| {
+        SensorError::KindMsgCause(
+            SensorErrorKind::Initialization,
+            "unable to create GPIO controller",
+            Box::new(e),
+        )
+    })?;
+
+    let pin = controller.get(bcm_gpio_pin).map_err(|e| {
+        SensorError::KindMsgCause(
+            SensorErrorKind::Initialization,
+            "unable to acquire pin from controller",
+            Box::new(e),
+        )
+    })?;
+
+    let io_pin = pin.into_io(Mode::Input);
+    Ok(io_pin)
+}
+
+/// Abstraction around an `rppal::gpio::IoPin` to allow for easier testing.
+pub trait DataPin {
+    fn is_low(&self) -> bool;
+    fn is_high(&self) -> bool;
+    fn pin(&self) -> u8;
+    fn set_high(&mut self);
+    fn set_low(&mut self);
+    fn set_mode(&mut self, mode: Mode);
+}
+
+impl DataPin for IoPin {
+    fn is_low(&self) -> bool {
+        IoPin::is_low(self)
+    }
+
+    fn is_high(&self) -> bool {
+        IoPin::is_high(self)
+    }
+
+    fn pin(&self) -> u8 {
+        IoPin::pin(self)
+    }
+
+    fn set_high(&mut self) {
+        IoPin::set_high(self);
+    }
+
+    fn set_low(&mut self) {
+        IoPin::set_low(self);
+    }
+
+    fn set_mode(&mut self, mode: Mode) {
+        IoPin::set_mode(self, mode);
+    }
+}

--- a/src/strudel/sensor/dht22.rs
+++ b/src/strudel/sensor/dht22.rs
@@ -16,107 +16,15 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-use rppal::gpio::{Gpio, IoPin, Mode};
-use std::error::Error;
-use std::fmt;
-use std::fmt::Formatter;
+use crate::sensor::core::{DataPin, Humidity, SensorError, SensorErrorKind, TemperatureCelsius};
+use rppal::gpio::Mode;
+use std::fmt::{Debug, Formatter};
 use std::thread;
 use std::time::Duration;
 
-const DHT_MAX_COUNT: u32 = 32_000;
-const DHT_PULSES: usize = 41;
-const DATA_SIZE: usize = 5;
-
-/// Temperature, in degrees celsius
-#[derive(Copy, Clone, Debug, PartialEq)]
-#[repr(transparent)]
-pub struct TemperatureCelsius(f64);
-
-impl From<TemperatureCelsius> for f64 {
-    fn from(v: TemperatureCelsius) -> Self {
-        v.0
-    }
-}
-
-impl fmt::Display for TemperatureCelsius {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}c", self.0)
-    }
-}
-
-/// Relative humidity (from 0 to 100)
-#[derive(Copy, Clone, Debug, PartialEq)]
-#[repr(transparent)]
-pub struct Humidity(f64);
-
-impl From<Humidity> for f64 {
-    fn from(v: Humidity) -> Self {
-        v.0
-    }
-}
-
-impl fmt::Display for Humidity {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}%", self.0)
-    }
-}
-
-/// Potential kinds of errors that can be encountered reading from the DHT sensor
-#[derive(PartialEq, Eq, Debug, Hash, Clone, Copy)]
-pub enum SensorErrorKind {
-    Initialization,
-    ReadTimeout,
-    Checksum,
-}
-
-impl SensorErrorKind {
-    pub fn as_label(&self) -> &'static str {
-        match self {
-            SensorErrorKind::Initialization => "initialization",
-            SensorErrorKind::ReadTimeout => "timeout",
-            SensorErrorKind::Checksum => "checksum",
-        }
-    }
-}
-
-/// Error initializing or reading the DHT22 sensor via a GPIO pin
-#[derive(Debug)]
-pub enum SensorError {
-    CheckSum(u8, u8),
-    KindMsg(SensorErrorKind, &'static str),
-    KindMsgCause(SensorErrorKind, &'static str, Box<dyn Error + Send + Sync>),
-}
-
-impl SensorError {
-    pub fn kind(&self) -> SensorErrorKind {
-        match self {
-            SensorError::CheckSum(_, _) => SensorErrorKind::Checksum,
-            SensorError::KindMsg(kind, _) => *kind,
-            SensorError::KindMsgCause(kind, _, _) => *kind,
-        }
-    }
-}
-
-impl fmt::Display for SensorError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            SensorError::CheckSum(expected, got) => {
-                write!(f, "checksum error: expected {}, got {}", expected, got)
-            }
-            SensorError::KindMsg(_, msg) => msg.fmt(f),
-            SensorError::KindMsgCause(_, msg, ref e) => write!(f, "{}: {}", msg, e),
-        }
-    }
-}
-
-impl Error for SensorError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            SensorError::KindMsgCause(_, _, ref e) => Some(e.as_ref()),
-            _ => None,
-        }
-    }
-}
+pub(crate) const DHT_MAX_COUNT: u32 = 32_000;
+pub(crate) const DHT_PULSES: usize = 41;
+pub(crate) const DATA_SIZE: usize = 5;
 
 /// Cycle counts of how long the sensor data pin spent low and high states.
 ///
@@ -138,7 +46,7 @@ impl Pulses {
     /// NOTE: This method assumes the pin as already been prepared for reading by sending
     /// and initial high-low-high transition with timings corresponding to the DHT22
     /// datasheet.
-    fn from_iopin(pin: &IoPin) -> Result<Self, SensorError> {
+    fn from_data_pin(pin: &dyn DataPin) -> Result<Self, SensorError> {
         // Create an array with 2x the number of pulses we're going to measure so that we can
         // store the number of cycles the pin spent high and low for each pulse.
         let mut counts: [u32; DHT_PULSES * 2] = [0; DHT_PULSES * 2];
@@ -177,7 +85,7 @@ impl Pulses {
     }
 
     /// Return an iterator over 40 cycle counts for the pin in the low state.
-    fn low(&self) -> impl Iterator<Item = &u32> {
+    fn low(&self) -> impl ExactSizeIterator<Item = &u32> {
         // Start from the 3rd element (first valid low count), emitting only low counts.
         // We're skipping the first low/high transition since the pin starts in the low
         // state when reading data and thus the first cycle count is always zero.
@@ -185,7 +93,7 @@ impl Pulses {
     }
 
     /// Return an iterator over 40 cycle counts for the pin in the high state.
-    fn high(&self) -> impl Iterator<Item = &u32> {
+    fn high(&self) -> impl ExactSizeIterator<Item = &u32> {
         // Start from the 4th element (first valid high count), emitting only high counts.
         // We're skipping the first low/high transition since the pin starts in the low
         // state when reading data and thus the first cycle count is always zero.
@@ -193,24 +101,24 @@ impl Pulses {
     }
 }
 
-/// Sensor data parsed from low/high cycle counts.
+/// Bytes read from a sensor, computed from high/low pulse cycle counts.
+///
+/// Bytes read make up temperature data, humidity data, and a checksum to ensure
+/// the reading is valid. If valid, the reading can be converted to a temperature
+/// and humidity valid.
 #[derive(Debug)]
 struct Reading {
     bytes: [u8; DATA_SIZE],
 }
 
 impl Reading {
-    /// Parse sensor data from the provided low/high pulse counts.
-    ///
-    /// An error will be returned if the checksum included in the data indicates the data
-    /// is corrupt.
     fn from_pulses(pulses: &Pulses) -> Result<Self, SensorError> {
         let mut bytes: [u8; DATA_SIZE] = [0; DATA_SIZE];
 
         // Find the average low pin cycle count so that we can determine if each high
         // pin cycle count is meant to be a 0 bit (lower than the threshold) or a 1 bit
         // (higher than the threshold).
-        let threshold = Self::pulse_threshold(pulses);
+        let threshold = pulses.low().sum::<u32>() / pulses.low().len() as u32;
 
         for (i, &v) in pulses.high().enumerate() {
             // There are 40 low/high transition cycle counts and hence 40 bits of data
@@ -227,73 +135,59 @@ impl Reading {
 
         // Byte five is a checksum of the first four bytes, return an error if it indicates
         // the data we've read is corrupt somehow.
-        Self::checksum(&bytes)?;
-        Ok(Self { bytes })
+        Self::checksum_bytes(&bytes)?;
+        Ok(Reading { bytes })
     }
 
-    /// Determine the threshold for high cycle counts to be treated as 0 or 1 based
-    /// on the average number of cycles the pin spends at low voltage.
-    fn pulse_threshold(pulses: &Pulses) -> u32 {
-        let mut threshold = 0;
-        let mut count = 0;
-
-        for v in pulses.low() {
-            threshold += v;
-            count += 1;
-        }
-
-        threshold /= count;
-
-        tracing::debug!(
-            message = "computing threshold from low pulse average",
-            threshold = threshold
-        );
-        threshold
-    }
-
-    /// Return an error if the checksum (byte 5) indicates the data read is corrupt.
-    fn checksum(data: &[u8; DATA_SIZE]) -> Result<(), SensorError> {
+    fn checksum_bytes(bytes: &[u8; DATA_SIZE]) -> Result<(), SensorError> {
         // From the DHT22 datasheet:
         // > If the data transmission is right, check-sum should be the last 8 bit of
         // > "8 bit integral RH data+8 bit decimal RH data+8 bit integral T data+8 bit
         // > decimal T data".
-        let expected = data[4];
-        let computed = ((data[0] as u16 + data[1] as u16 + data[2] as u16 + data[3] as u16) & 0xFF) as u8;
+        let expected = bytes[4];
+        let computed = ((bytes[0] as u16 + bytes[1] as u16 + bytes[2] as u16 + bytes[3] as u16) & 0xFF) as u8;
 
         tracing::debug!(
             message = "computing checksum for sensor data",
             computed = computed,
             expected = expected
         );
+
         if computed != expected {
             Err(SensorError::CheckSum(expected, computed))
         } else {
             Ok(())
         }
     }
+}
 
-    /// Parse data bytes into temperature celsius and relative humidity.
-    fn parse(&self) -> (TemperatureCelsius, Humidity) {
+impl From<Reading> for (TemperatureCelsius, Humidity) {
+    /// Convert a `Reading` sensor reading into temperature and humidity measurements.
+    ///
+    /// This conversion is guaranteed to succeed because the checksum enforced during creation
+    /// of instances of `Reading` ensures the bytes read from the sensor are valid.
+    fn from(reading: Reading) -> Self {
         // See https://cdn-shop.adafruit.com/datasheets/Digital+humidity+and+temperature+sensor+AM2302.pdf
         // first two bytes are humidity as a u16 * 10
-        let h = (self.bytes[0] as u16) * 256 /* shift left 8 bits */ + self.bytes[1] as u16;
+        let humidity_raw = (reading.bytes[0] as u16) * 256 /* shift left 8 bits */ + reading.bytes[1] as u16;
         // second two bytes are temperature as a u16 * 10 with the highest bit indicating sign
-        let t = ((self.bytes[2] & 0b0111_1111) as u16) * 256 /* shift left 8 bits */ + self.bytes[3] as u16;
+        let temp_raw =
+            ((reading.bytes[2] & 0b0111_1111) as u16) * 256 /* shift left 8 bits */ + reading.bytes[3] as u16;
 
-        let hdec = h as f64 / 10.0;
-        let mut tdec = t as f64 / 10.0;
+        let humidity_dec = humidity_raw as f64 / 10.0;
+        let mut temp_dec = temp_raw as f64 / 10.0;
         // highest bit of the temperature is `1` to indicate a negative value
-        if self.bytes[2] & 0b1000_0000 > 0 {
-            tdec = -tdec;
+        if reading.bytes[2] & 0b1000_0000 > 0 {
+            temp_dec = -temp_dec;
         }
 
-        let humidity = Humidity(hdec);
-        let temperature = TemperatureCelsius(tdec);
+        let humidity = Humidity::from(humidity_dec);
+        let temperature = TemperatureCelsius::from(temp_dec);
 
         tracing::debug!(
             message = "parsed sensor data",
-            raw_temperature = t,
-            raw_humidity = h,
+            raw_temperature = temp_raw,
+            raw_humidity = humidity_raw,
             temperature = %temperature,
             humidity = %humidity
         );
@@ -303,40 +197,18 @@ impl Reading {
 }
 
 /// Read temperature in degrees celsius and relative humidity from a DHT22 sensor
-#[derive(Debug)]
-pub struct TemperatureReader {
-    pin: IoPin,
+pub struct DHT22Sensor {
+    pin: Box<dyn DataPin + Send + Sync + 'static>,
 }
 
-impl TemperatureReader {
-    /// Create a new reader based on the BCM GPIO pin number of the data wire of
-    /// the DHT22 sensor.
-    ///
-    /// Note that the BCM GPIO pin number is NOT the same as the physical pin number.
-    /// See [pinout] for more information.
-    ///
-    /// [pinout]: https://www.raspberrypi.com/documentation/computers/os.html#gpio-and-the-40-pin-header
-    pub fn new(bcm_gpio_pin: u8) -> Result<Self, SensorError> {
-        let controller = Gpio::new().map_err(|e| {
-            SensorError::KindMsgCause(
-                SensorErrorKind::Initialization,
-                "unable to create GPIO controller",
-                Box::new(e),
-            )
-        })?;
-        let pin = controller.get(bcm_gpio_pin).map_err(|e| {
-            SensorError::KindMsgCause(
-                SensorErrorKind::Initialization,
-                "unable to acquire pin from controller",
-                Box::new(e),
-            )
-        })?;
-        let io_pin = pin.into_io(Mode::Input);
-
-        Ok(Self { pin: io_pin })
+impl DHT22Sensor {
+    pub fn from_pin<T>(pin: T) -> Self
+    where
+        T: DataPin + Send + Sync + 'static,
+    {
+        Self { pin: Box::new(pin) }
     }
 
-    /// Send a high-low-high signal to indicate the sensor should perform a read
     fn prepare_for_read(&mut self) {
         // https://cdn-shop.adafruit.com/datasheets/Digital+humidity+and+temperature+sensor+AM2302.pdf
         // Host needs to set the sensor:
@@ -345,9 +217,9 @@ impl TemperatureReader {
         // * high for 20-40us to then wait for the sensor's response
         self.pin.set_mode(Mode::Output);
         self.pin.set_high();
-        thread::sleep(Duration::from_millis(50));
+        thread::sleep(Duration::from_millis(10));
         self.pin.set_low();
-        thread::sleep(Duration::from_millis(30));
+        thread::sleep(Duration::from_millis(20));
         self.pin.set_high();
         thread::sleep(Duration::from_micros(30));
         self.pin.set_mode(Mode::Input);
@@ -355,95 +227,46 @@ impl TemperatureReader {
 
     /// Read temperature and humidity from the sensor or return an error if the
     /// read failed with details about what caused the read to fail.
-    ///
-    /// Note the DHT22 sensor should only be read every two seconds at max. This shouldn't
-    /// be an issue in practice since Prometheus scrape intervals are usually at least
-    /// 10 seconds.
     pub fn read(&mut self) -> Result<(TemperatureCelsius, Humidity), SensorError> {
         self.prepare_for_read();
-        let pulses = Pulses::from_iopin(&self.pin)?;
-        let reading = Reading::from_pulses(&pulses)?;
-        Ok(reading.parse())
+        let pulses = Pulses::from_data_pin(self.pin.as_ref())?;
+        let data = Reading::from_pulses(&pulses)?;
+        Ok(data.into())
+    }
+}
+
+impl Debug for DHT22Sensor {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DHT22Sensor").field("pin", &self.pin.pin()).finish()
     }
 }
 
 #[cfg(test)]
 mod test {
-    use super::{Humidity, Pulses, Reading, SensorError, TemperatureCelsius, DATA_SIZE, DHT_PULSES};
+    use super::{DHT22Sensor, Pulses, Reading, DATA_SIZE};
+    use crate::sensor::core::{Humidity, SensorError, SensorErrorKind, TemperatureCelsius};
+    use crate::sensor::test::{MockDataPin, NopDataPin, TimeoutDataPin};
 
-    fn new_counts() -> [u32; DHT_PULSES * 2] {
-        #[rustfmt::skip]
-        let counts = [
-            0, 761,
-            561, 307,
-            559, 295,
-            598, 307,
-            589, 307,
-            591, 307,
-            598, 307,
-            591, 866,
-            592, 854,
-            570, 748,
-            598, 860,
-            598, 859,
-            596, 307,
-            590, 307,
-            598, 859,
-            599, 859,
-            598, 847,
-            748, 300,
-            593, 296,
-            589, 307,
-            598, 300,
-            598, 307,
-            591, 307,
-            598, 307,
-            590, 847,
-            748, 307,
-            592, 306,
-            599, 299,
-            598, 307,
-            591, 307,
-            598, 307,
-            591, 307,
-            591, 855,
-            708, 867,
-            590, 866,
-            591, 867,
-            591, 307,
-            598, 859,
-            598, 859,
-            598, 300,
-            598, 295,
-        ];
+    #[test]
+    fn test_pulses_timeout() {
+        let pin = TimeoutDataPin;
+        let res = Pulses::from_data_pin(&pin);
 
-        counts
+        assert!(res.is_err());
+        assert_eq!(SensorErrorKind::ReadTimeout, res.unwrap_err().kind());
     }
 
     #[test]
-    fn test_reading_from_pulses() {
-        let pulses = Pulses { counts: new_counts() };
-        let res = Reading::from_pulses(&pulses);
+    fn test_pulses_nop() {
+        let pin = NopDataPin;
+        let res = Pulses::from_data_pin(&pin);
 
-        assert!(res.is_ok(), "unexpected error result: {:?}", res);
-
-        let reading = res.unwrap();
-        let (t, h) = reading.parse();
-
-        assert_eq!(TemperatureCelsius(25.7), t);
-        assert_eq!(Humidity(99.9), h);
-    }
-
-    #[test]
-    fn test_reading_threshold() {
-        let pulses = Pulses { counts: new_counts() };
-        let threshold = Reading::pulse_threshold(&pulses);
-
-        assert_eq!(602, threshold);
+        assert!(res.is_ok());
     }
 
     #[test]
     fn test_reading_checksum_valid() {
+        // Example data, from the datasheet: https://cdn-shop.adafruit.com/datasheets/Digital+humidity+and+temperature+sensor+AM2302.pdf
         let mut bytes = [0; DATA_SIZE];
         bytes[0] = 0b0000_0010; // humidity 1
         bytes[1] = 0b1000_1100; // humidity 2
@@ -451,7 +274,7 @@ mod test {
         bytes[3] = 0b0101_1111; // temperature 2
         bytes[4] = 0b1110_1110; // checksum
 
-        let res = Reading::checksum(&bytes);
+        let res = Reading::checksum_bytes(&bytes);
         assert!(res.is_ok())
     }
 
@@ -462,9 +285,9 @@ mod test {
         bytes[1] = 0b1000_1100; // humidity 2
         bytes[2] = 0b0000_0001; // temperature 1
         bytes[3] = 0b0101_1111; // temperature 2
-        bytes[4] = 0b0000_0000; // checksum
+        bytes[4] = 0b0000_0000; // checksum, invalid
 
-        let res = Reading::checksum(&bytes);
+        let res = Reading::checksum_bytes(&bytes);
         assert!(res.is_err());
 
         match res.unwrap_err() {
@@ -482,7 +305,7 @@ mod test {
     }
 
     #[test]
-    fn test_reading_parse_positive_temp() {
+    fn test_reading_into_positive_temp() {
         // Example data, from the datasheet: https://cdn-shop.adafruit.com/datasheets/Digital+humidity+and+temperature+sensor+AM2302.pdf
         let mut bytes = [0; 5];
         bytes[0] = 0b0000_0010; // humidity 1
@@ -491,15 +314,14 @@ mod test {
         bytes[3] = 0b0101_1111; // temperature 2
         bytes[4] = 0b0000_0000; // checksum, ignored here
 
-        let reading = Reading { bytes };
-        let (t, h) = reading.parse();
+        let (t, h) = Reading { bytes }.into();
 
-        assert_eq!(TemperatureCelsius(35.1), t);
-        assert_eq!(Humidity(65.2), h);
+        assert_eq!(TemperatureCelsius::from(35.1), t);
+        assert_eq!(Humidity::from(65.2), h);
     }
 
     #[test]
-    fn test_reading_parse_negative_temp() {
+    fn test_reading_into_negative_temp() {
         // Example data, from the datasheet: https://cdn-shop.adafruit.com/datasheets/Digital+humidity+and+temperature+sensor+AM2302.pdf
         let mut bytes = [0; 5];
         bytes[0] = 0b0000_0010; // humidity 1
@@ -508,10 +330,46 @@ mod test {
         bytes[3] = 0b0110_0101; // temperature 2
         bytes[4] = 0b0000_0000; // checksum, ignored here
 
-        let reading = Reading { bytes };
-        let (t, h) = reading.parse();
+        let (t, h) = Reading { bytes }.into();
 
-        assert_eq!(TemperatureCelsius(-10.1), t);
-        assert_eq!(Humidity(65.2), h);
+        assert_eq!(TemperatureCelsius::from(-10.1), t);
+        assert_eq!(Humidity::from(65.2), h);
+    }
+
+    #[test]
+    fn test_dht22_sensor_read_valid() {
+        // Example data, from the datasheet: https://cdn-shop.adafruit.com/datasheets/Digital+humidity+and+temperature+sensor+AM2302.pdf
+        let mut bytes = [0; DATA_SIZE];
+        bytes[0] = 0b0000_0010; // humidity 1
+        bytes[1] = 0b1000_1100; // humidity 2
+        bytes[2] = 0b0000_0001; // temperature 1
+        bytes[3] = 0b0101_1111; // temperature 2
+        bytes[4] = 0b1110_1110; // checksum
+
+        let pin = MockDataPin::new(bytes);
+        let mut sensor = DHT22Sensor::from_pin(pin);
+        let res = sensor.read();
+        let (t, h) = res.unwrap();
+
+        assert_eq!(TemperatureCelsius::from(35.1), t);
+        assert_eq!(Humidity::from(65.2), h);
+    }
+
+    #[test]
+    fn test_dht22_sensor_read_invalid() {
+        // Example data, from the datasheet: https://cdn-shop.adafruit.com/datasheets/Digital+humidity+and+temperature+sensor+AM2302.pdf
+        let mut bytes = [0; DATA_SIZE];
+        bytes[0] = 0b0000_0010; // humidity 1
+        bytes[1] = 0b1000_1100; // humidity 2
+        bytes[2] = 0b0000_0001; // temperature 1
+        bytes[3] = 0b0101_1111; // temperature 2
+        bytes[4] = 0b0000_0000; // checksum, invalid
+
+        let pin = MockDataPin::new(bytes);
+        let mut sensor = DHT22Sensor::from_pin(pin);
+        let res = sensor.read();
+
+        assert!(res.is_err());
+        assert_eq!(SensorErrorKind::Checksum, res.unwrap_err().kind());
     }
 }

--- a/src/strudel/sensor/mod.rs
+++ b/src/strudel/sensor/mod.rs
@@ -1,0 +1,24 @@
+// Strudel - Temperature and humidity metrics exporter for Prometheus
+//
+// Copyright 2021 Nick Pillitteri
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+mod core;
+mod dht22;
+mod test;
+
+pub use crate::sensor::core::{open_pin, DataPin, Humidity, SensorError, SensorErrorKind, TemperatureCelsius};
+pub use crate::sensor::dht22::DHT22Sensor;

--- a/src/strudel/sensor/test.rs
+++ b/src/strudel/sensor/test.rs
@@ -1,0 +1,189 @@
+// Strudel - Temperature and humidity metrics exporter for Prometheus
+//
+// Copyright 2021 Nick Pillitteri
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+#![cfg(test)]
+
+use crate::sensor::dht22::DATA_SIZE;
+use crate::sensor::DataPin;
+use rppal::gpio::Mode;
+use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
+
+const LOW_CYCLE_COUNT: u32 = 400;
+const ONE_CYCLE_COUNT: u32 = 600;
+const ZERO_CYCLE_COUNT: u32 = 200;
+
+/// DataPin implementation specifically to test timeouts in Pulse::from_data_pin
+pub(crate) struct TimeoutDataPin;
+
+impl DataPin for TimeoutDataPin {
+    fn is_low(&self) -> bool {
+        true
+    }
+
+    fn is_high(&self) -> bool {
+        true
+    }
+
+    fn pin(&self) -> u8 {
+        0
+    }
+
+    fn set_high(&mut self) {
+        // NOP
+    }
+
+    fn set_low(&mut self) {
+        // NOP
+    }
+
+    fn set_mode(&mut self, _mode: Mode) {
+        // NOP
+    }
+}
+
+/// DataPin implementation specifically to test non-timeout cases in Pulse::from_data_pin
+pub(crate) struct NopDataPin;
+
+impl DataPin for NopDataPin {
+    fn is_low(&self) -> bool {
+        false
+    }
+
+    fn is_high(&self) -> bool {
+        false
+    }
+
+    fn pin(&self) -> u8 {
+        0
+    }
+
+    fn set_high(&mut self) {
+        // NOP
+    }
+
+    fn set_low(&mut self) {
+        // NOP
+    }
+
+    fn set_mode(&mut self, _mode: Mode) {
+        // NOP
+    }
+}
+
+/// DataPin implementation that uses expected sensor data to generate pulse counts.
+/// Used to verify behavior of Pulse::from_data_pin and Reading::from_pulses.
+pub(crate) struct MockDataPin {
+    data: [u8; DATA_SIZE],
+    bit_idx: AtomicUsize,
+    high_count: AtomicU32,
+    low_count: AtomicU32,
+
+    init_high: AtomicU32,
+    init_low: AtomicU32,
+}
+
+impl MockDataPin {
+    pub(crate) fn new(data: [u8; DATA_SIZE]) -> Self {
+        MockDataPin {
+            data,
+            bit_idx: Default::default(),
+            high_count: Default::default(),
+            low_count: Default::default(),
+            init_high: Default::default(),
+            init_low: Default::default(),
+        }
+    }
+
+    fn is_current_bit_on(&self) -> bool {
+        let idx = self.bit_idx.load(Ordering::SeqCst);
+        let byte_idx = idx / 8;
+        // We look at the LSB of each byte to match sensor behavior
+        let bit_offset = 8 - (idx % 8) - 1;
+        let bit_mask: u8 = 0x01 << bit_offset;
+
+        self.data[byte_idx] & bit_mask > 0
+    }
+
+    fn next_bit(&self) {
+        self.bit_idx.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+impl DataPin for MockDataPin {
+    fn is_low(&self) -> bool {
+        // The initial low/high transition is discarded so immediately short-circuit
+        // here before getting into the actual pulse counts based on our data.
+        let init = self.init_low.fetch_add(1, Ordering::SeqCst);
+        if init == 0 {
+            return false;
+        }
+
+        // Return true for a fixed number of invocations then reset.
+        let count = self.low_count.fetch_add(1, Ordering::SeqCst);
+        if count >= LOW_CYCLE_COUNT {
+            self.low_count.store(0, Ordering::SeqCst);
+            false
+        } else {
+            true
+        }
+    }
+
+    fn is_high(&self) -> bool {
+        // The initial low/high transition is discarded so immediately short-circuit
+        // here before getting into the actual pulse counts based on our data.
+        let init = self.init_high.fetch_add(1, Ordering::SeqCst);
+        if init == 0 {
+            return false;
+        }
+
+        // Look at the current bit and figure out if we should use the pulse count
+        // to indicate this is a one or the pulse count to indicate this is a zero.
+        let target = if self.is_current_bit_on() {
+            ONE_CYCLE_COUNT
+        } else {
+            ZERO_CYCLE_COUNT
+        };
+
+        // Return true some number of times (to indicate one or zero) and then reset,
+        // incrementing the counter that tells us which bit we should be looking at.
+        let count = self.high_count.fetch_add(1, Ordering::SeqCst);
+        if count >= target {
+            self.high_count.store(0, Ordering::SeqCst);
+            self.next_bit();
+            false
+        } else {
+            true
+        }
+    }
+
+    fn pin(&self) -> u8 {
+        0
+    }
+
+    fn set_high(&mut self) {
+        // NOP
+    }
+
+    fn set_low(&mut self) {
+        // NOP
+    }
+
+    fn set_mode(&mut self, _mode: Mode) {
+        // NOP
+    }
+}


### PR DESCRIPTION
* Split update of metrics from sensor read and drive sensor reads from a periodic task in the binary.
* Introduce DataPin abstraction to allow unit testing of more sensor components using mock data.
* Sensor is now called DHT22Sensor in case we decide to support more than a single sensor in Strudel.